### PR TITLE
Add properties for long and short bank name to BIC

### DIFF
--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -110,10 +110,24 @@ class BIC(Base):
 
     @property
     def country_bank_code(self):
-        """str or None: The country specific bank-code associated to the BIC."""
+        """str or None: The country specific bank-code associated with the BIC."""
         entry = registry.get('bic').get(self.compact)
         if entry:
             return entry.get('bank_code')
+
+    @property
+    def bank_name(self):
+        """str or None: The name of the bank associated with the BIC."""
+        entry = registry.get('bic').get(self.compact)
+        if entry:
+            return entry.get('name')
+
+    @property
+    def bank_short_name(self):
+        """str or None: The short name of the bank associated with the BIC."""
+        entry = registry.get('bic').get(self.compact)
+        if entry:
+            return entry.get('short_name')
 
     @property
     def exists(self):

--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -154,12 +154,12 @@ class BIC(Base):
 
     bank_code = property(partial(Base._get_component, start=0, end=4),
                          doc="str: The bank-code part of the BIC.")
-    branch_code = property(partial(Base._get_component, start=8, end=11),
-                           doc="str or None: The branch-code part of the BIC (if available)")
     country_code = property(partial(Base._get_component, start=4, end=6),
                             doc="str: The ISO 3166 alpha2 country-code.")
     location_code = property(partial(Base._get_component, start=6, end=8),
                              doc="str: The location code of the BIC.")
+    branch_code = property(partial(Base._get_component, start=8, end=11),
+                           doc="str or None: The branch-code part of the BIC (if available)")
 
 
 registry.build_index('bank', 'bic', 'bic')

--- a/tests/test_bic.py
+++ b/tests/test_bic.py
@@ -44,10 +44,10 @@ def test_unknown_bic_properties():
     assert bic.country_code == 'JP'
     assert bic.location_code == 'JT'
     assert bic.branch_code == 'XXX'
-    assert bic.country_bank_code == None
-    assert bic.bank_name == None
-    assert bic.bank_short_name == None
-    assert bic.exists == False
+    assert bic.country_bank_code is None
+    assert bic.bank_name is None
+    assert bic.bank_short_name is None
+    assert not bic.exists
     assert bic.type == 'default'
 
 

--- a/tests/test_bic.py
+++ b/tests/test_bic.py
@@ -23,21 +23,32 @@ def test_bic_no_branch_code():
     assert bic.formatted == 'GENO DE M1'
 
 
-def test_country_bank_code():
-    assert BIC('ABNAJPJTXXX').country_bank_code is None
-    assert BIC('GENODEM1GLS').country_bank_code == '43060967'
-
-
 def test_bic_properties():
     bic = BIC('GENODEM1GLS')
     assert bic.length == 11
     assert bic.bank_code == 'GENO'
-    assert bic.branch_code == 'GLS'
     assert bic.country_code == 'DE'
     assert bic.location_code == 'M1'
+    assert bic.branch_code == 'GLS'
     assert bic.country_bank_code == '43060967'
+    assert bic.bank_name == 'GLS Gemeinschaftsbank'
+    assert bic.bank_short_name == 'GLS Gemeinschaftsbk Bochum'
     assert bic.exists
     assert bic.type == 'passive'
+
+
+def test_unknown_bic_properties():
+    bic = BIC('ABNAJPJTXXX')
+    assert bic.length == 11
+    assert bic.bank_code == 'ABNA'
+    assert bic.country_code == 'JP'
+    assert bic.location_code == 'JT'
+    assert bic.branch_code == 'XXX'
+    assert bic.country_bank_code == None
+    assert bic.bank_name == None
+    assert bic.bank_short_name == None
+    assert bic.exists == False
+    assert bic.type == 'default'
 
 
 @pytest.mark.parametrize('code,type', [


### PR DESCRIPTION
This pull requests enables getting a bank's name and short_name as bank_name and bank_short_name properties of a BIC object. This data is already present in bank-registry.json .
This also adds the two new fields to the appropriate tests. Testing is refactored to avoid checking the same thing multiple times. The order of the BIC properties in the code is changed to follow the structure of a BIC. Additionally, a docstring typo is fixed.